### PR TITLE
4 containerize rust project with docker

### DIFF
--- a/options_analyzer/Dockerfile
+++ b/options_analyzer/Dockerfile
@@ -1,10 +1,7 @@
-FROM rust:1.72.0 as builder
-WORKDIR /usr/src/options_analyzer
-COPY . .
-RUN cargo install --path .
-FROM debian:buster-slim
-RUN apt-get update & apt-get install -y curl
-RUN apt-get update & apt-get install -y extra-runtime-dependencies & rm -rf /var/lib/apt/lists/*
-COPY --from=builder /usr/local/cargo/bin/options_analyzer /usr/local/bin/options_analyzer
-CMD ["options_analyzer"]
+FROM rust
 
+COPY . . 
+
+RUN cargo build --release
+
+CMD ["target/release/options_analyzer"]

--- a/options_analyzer/Dockerfile
+++ b/options_analyzer/Dockerfile
@@ -1,0 +1,10 @@
+FROM rust:1.72.0 as builder
+WORKDIR /usr/src/options_analyzer
+COPY . .
+RUN cargo install --path .
+FROM debian:buster-slim
+RUN apt-get update & apt-get install -y curl
+RUN apt-get update & apt-get install -y extra-runtime-dependencies & rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/options_analyzer /usr/local/bin/options_analyzer
+CMD ["options_analyzer"]
+


### PR DESCRIPTION
* Containerize rust project in order to add side services such as RabbitMQ and Postgres