### PR TITLE
12 improve publishing to queue function on mq package

### DIFF
--- a/options_analyzer/src/main.rs
+++ b/options_analyzer/src/main.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let queue_name = "parsing_queue";
 
-        //Add queue to background thread (Necessary?)
+        //Add queue to background thread 
         let _ = match mq_connection_c.add_queue(sub_channel.as_mut().unwrap(), queue_name, parsing_routing_key, "amq.direct").await {
             Ok(_) => {},
             Err(e) => {
@@ -205,8 +205,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     mq::publish_to_queue(pub_channel.as_mut().unwrap(), exchange_name, parsing_routing_key, content).await?;
     println!("Item Published! from main");
-
-
+    
     //let future = async {
 
         // Define a periodic interval

--- a/options_analyzer/src/mq.rs
+++ b/options_analyzer/src/mq.rs
@@ -117,9 +117,6 @@ impl<'a> MQConnection<'a> {
         Ok(())
     }
 
-
-
-    //TODO: Add error handling (return result type here)
     pub async fn close_connections(&self) -> Result<(), Box<dyn std::error::Error>> {
         self.connection.clone().expect("mq::close_connections - Connection was None while closing").close().await?;
 

--- a/options_analyzer/src/mq.rs
+++ b/options_analyzer/src/mq.rs
@@ -66,7 +66,6 @@ impl<'a> MQConnection<'a> {
         Ok(())
     }
 
-    //TODO: Change return to Option or Result type
     pub async fn add_channel(&self, channel_id: Option<AmqpChannelId>) -> Result<Channel, Box<dyn std::error::Error>> {
         let connection = self.connection.clone();
 
@@ -80,12 +79,11 @@ impl<'a> MQConnection<'a> {
 
             Ok(channel)
         } else {
-            Err("Connection was None".into())
+            Err("mq::add_channel: Connection was None".into())
         }
     }
 
     //add queue method
-    //TODO: Add error handling (return result type here)
     pub async fn add_queue(&mut self, channel: &mut Channel, queue_name: &str, routing_key: &str, exchange_name: &str) -> Result<(), Box<dyn std::error::Error>> {
         //Declare queue
         let option_args = match channel.queue_declare(QueueDeclareArguments::durable_client_named(queue_name)).await {            
@@ -102,7 +100,7 @@ impl<'a> MQConnection<'a> {
             } 
         };
         if option_args.is_none() {
-            return Err("Queue was None after declaring".into()); 
+            return Err("mq::add_queue - Queue was None after declaring".into()); 
         }
         
 

--- a/options_analyzer/src/mq.rs
+++ b/options_analyzer/src/mq.rs
@@ -48,6 +48,9 @@ impl<'a> MQConnection<'a> {
         }
 
     }
+
+    //open method for opening a connection to the mq server based on the host, port, username, and
+    //password passed into the mq struct
     pub async fn open(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let connection = Connection::open(&OpenConnectionArguments::new(
             self.host,
@@ -66,6 +69,7 @@ impl<'a> MQConnection<'a> {
         Ok(())
     }
 
+    //add channel method for adding a channel to an mq connection and returning the new channel
     pub async fn add_channel(&self, channel_id: Option<AmqpChannelId>) -> Result<Channel, Box<dyn std::error::Error>> {
         let connection = self.connection.clone();
 
@@ -83,7 +87,7 @@ impl<'a> MQConnection<'a> {
         }
     }
 
-    //add queue method
+    //add queue method for adding a queue to the current channel
     pub async fn add_queue(&mut self, channel: &mut Channel, queue_name: &str, routing_key: &str, exchange_name: &str) -> Result<(), Box<dyn std::error::Error>> {
         //Declare queue
         let option_args = match channel.queue_declare(QueueDeclareArguments::durable_client_named(queue_name)).await {            
@@ -114,7 +118,8 @@ impl<'a> MQConnection<'a> {
 
         Ok(())
     }
-
+    
+    //close_connections closes all connections to the MQ server
     pub async fn close_connections(&self) -> Result<(), Box<dyn std::error::Error>> {
         self.connection.clone().expect("mq::close_connections - Connection was None while closing").close().await?;
 

--- a/options_analyzer/src/parsing_queue.rs
+++ b/options_analyzer/src/parsing_queue.rs
@@ -5,12 +5,12 @@ extern crate async_trait;
 extern crate tokio;
 
 use amqprs::{
-    channel::{BasicAckArguments, BasicConsumeArguments, Channel},
+    channel::{BasicAckArguments, BasicConsumeArguments, Channel, BasicCancelArguments},
     consumer::AsyncConsumer,
     BasicProperties,
     Deliver,
 };
-use std::{borrow::BorrowMut, ops::{Deref, DerefMut}, str, sync::Arc, time::Duration, future::Future};
+use std::{borrow::BorrowMut, future::Future, ops::{Deref, DerefMut}, str, sync::Arc, time::Duration};
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio::sync::{Mutex, mpsc::Sender, oneshot};
@@ -48,22 +48,150 @@ impl<'a> ParsingQueue<'a> {
     }
     
     //Start a consumer on channel
-    //NEED a separate consumer struct here
-    //TODO: Add Result type as return to handle errors
-    pub async fn process_queue(&mut self, channel: &mut Channel) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn process_queue(&mut self, channel: &mut Channel, pub_channel: &mut Channel) -> Result<(), Box<dyn std::error::Error>> {
         let args = BasicConsumeArguments::new(
             &self.name,
             "parser",
-        );
+        ).manual_ack(false)
+        .finish();
 
         self.parsing_consumer = Some(ParsingConsumer::new(args.no_ack, self.tx.clone()));
 
-        //Possible declare a new consumer here with cache on it
-        let consumer_tag = channel
-            .basic_consume(self.parsing_consumer.clone().unwrap(), args)
-            .await?;
+        //Possible declare a new basic_consume_rx(args) 
+        //let consumer_tag = channel
+        //    .basic_consume(self.parsing_consumer.clone().unwrap(), args)
+        //    .await?;
 
-        dbg!(consumer_tag);
+        //consuming behavior defined here
+        let (ctag, mut messages_rx) = channel.basic_consume_rx(args.clone()).await?;
+        while let Some(deliver) = messages_rx.recv().await {
+           //need to convert to another function
+           let content = match deliver.content {
+               Some(x) => x,
+               None => continue,
+           };
+
+
+           //unserialize content
+           let stringed_bytes = match str::from_utf8(&content) {
+               Ok(stringed) => stringed,
+               Err(e) => {
+                   let msg = format!("parsing_queue.AsyncConsumer.consume - stringing content bytes failed {}", e);
+                   println!("{}", msg);
+                   ""
+               },
+           };
+           let unserialized_content: Value = match serde_json::from_str(&stringed_bytes) {
+               Ok(unser_con) => unser_con,
+               Err(e) => {
+                   let msg = format!("parsing_queue.AsyncConsumer.consume - unserializing content into json failed {}", e);
+                   println!("{}", msg);
+                   //Panic!
+                   Value::Null
+
+               }
+           };
+           println!("Unserialized Content: {:?}", unserialized_content);
+           if unserialized_content.is_null()|| unserialized_content["symbol"].is_null() {
+               println!("Symbol is null! for the following delivery: {}",unserialized_content);
+               let args = BasicAckArguments::new(deliver.deliver.unwrap().delivery_tag(), false);
+
+               match channel.basic_ack(args).await {
+                   Ok(_) => {}
+                   Err(e) => {
+                       let msg = format!("parsing_queue.AsyncConsumer.consume - Error occurred while acking message after null content: {}", e);
+                       println!("{}", msg);
+                   },
+               }
+
+           } else {
+               let symbol = unserialized_content["symbol"].to_string().replace("\"", "");
+               println!("SYMBOL: {:?}\n", symbol);
+               let url = format!(r#"https://finance.yahoo.com/quote/{}/options?p={}"#, symbol, symbol);
+               println!("URL: {:?}\n", url);
+               let output_ts = match options_scraper::async_scrape(url.as_str()).await {
+                   Ok(x) => x,
+                   Err(e) => {
+                       let msg = format!("parsing_queue.AsyncConsumer.consume - Error occurred while scraping: {}", e);
+                       println!("{}", msg);
+                       //Panic! here?
+                       options_scraper::TimeSeries {
+                           data: Vec::new(),
+                       }
+                   },
+               }; 
+           
+
+               println!("Serialized Object LENGTH: {:?}", output_ts.data.len());
+
+               //Parse out fields of time series objects from string => correct datatype
+               let mut contracts: Vec<Contract> = Vec::new();
+
+               for i in output_ts.data.iter() {
+                   let (resp_tx, resp_rx) = oneshot::channel();
+                   println!("Contract: {:?}\n", i.clone());
+                   let contract = Contract::new_from_unparsed(i);
+                   let command = Command::Set{
+                       key: contract.contract_name.clone(),
+                       value: contract,
+                       resp: resp_tx,
+                   };
+                   match self.tx.send(command).await {
+                       Ok(_) => {
+
+                       },
+                       Err(e) => {
+                           let msg = format!("parsing_queue.AsyncConsumer.consume - Error occurred while sending contract to cache: {}", e);
+                           println!("{}", msg);
+                       },
+                   };
+                   let resp = match resp_rx.await {
+                       Ok(x) => x,
+                       Err(e) => {
+                           let msg = format!("parsing_queue.AsyncConsumer.consume - Error occurred while receiving result of sending contract to cache: {}", e);
+                           println!("{}", msg);
+                           Err(()) 
+                       },
+                   };
+                   dbg!(resp);
+               }
+
+               //dbg!(contracts);
+
+
+               //Wait until channel logic is fixed to run the commented out code below
+               let e_content = String::from(
+                   r#"
+                       {
+                           "publisher": "parsing",
+                           "data": "Hello, from Parsing Queue"
+                       }
+                   "#,
+               ).into_bytes();
+               //Insert into next queue (need to find channel based on queue name and send it through that channel)
+               publish_to_queue(pub_channel, "amq.direct", "amqprs.example", e_content).await;
+
+               let args = BasicAckArguments::new(deliver.deliver.unwrap().delivery_tag(), false);
+
+               match channel.basic_ack(args).await {
+                   Ok(_) => {}
+                   Err(e) => {
+                       let msg = format!("parsing_queue.AsyncConsumer.consume - Error occurred while acking message: {}", e);
+                       println!("{}", msg);
+                        //println!("DELIVERY TAG: {}", deliver.deliver.unwrap().delivery_tag())
+                   },
+               };
+               //println!("DELIVERY TAG: {}", deliver.deliver.unwrap().delivery_tag())
+
+           }
+        }
+
+        if let Err(e) = channel.basic_cancel(BasicCancelArguments::new(&ctag)).await {
+                let msg = format!("parsing_queue.AsyncConsumer.process_queue - Error occurred while cancelling consumer: {}", e);
+                println!("{}", msg);
+        }
+
+        dbg!(ctag);
         Ok(())
         
     }
@@ -90,7 +218,6 @@ impl<'a> Queue for ParsingQueue<'a> {
 struct ParsingConsumer {
     no_ack: bool,
     tx: Sender<Command>,
-    //tx: Arc<Mutex<mpsc::Sender<Command>>>,
     //additional fields as needed
 }
 
@@ -106,7 +233,6 @@ impl ParsingConsumer {
 #[async_trait]
 impl AsyncConsumer for ParsingConsumer {
 
-    //TODO: Add error handling to function 
     async fn consume(
         &mut self,
         channel: &Channel,
@@ -202,17 +328,16 @@ impl AsyncConsumer for ParsingConsumer {
 
 
             //Wait until channel logic is fixed to run the commented out code below
-            //let e_content = String::from(
-            //    r#"
-            //        {
-            //            "publisher": "parsing",
-            //            "data": "Hello, from Parsing Queue"
-            //        }
-            //    "#,
-            //).into_bytes();
-            //Insert into next queue (need to find channel based on queue name and send it through that
-            //channel)
-            //publish_to_queue(channel, "amq.direct", "amqprs.example", e_content).await;
+            let e_content = String::from(
+                r#"
+                    {
+                        "publisher": "parsing",
+                        "data": "Hello, from Parsing Queue"
+                    }
+                "#,
+            ).into_bytes();
+            //Insert into next queue (need to find channel based on queue name and send it through that channel)
+            publish_to_queue(channel, "amq.direct", "amqprs.example", e_content).await;
 
             let args = BasicAckArguments::new(deliver.delivery_tag(), false);
 


### PR DESCRIPTION
- Fixed publishing structure and queue sequencing to execute in a more consistent manner
- Changed parsing queue to publish each contract to next queue rather than batch of contracts scraped
- Fixed publishing to use own channel rather than reusing current channel consuming